### PR TITLE
Use user username instead of client identifier (which is a random id)

### DIFF
--- a/Security/Authenticator/Oauth2Authenticator.php
+++ b/Security/Authenticator/Oauth2Authenticator.php
@@ -70,7 +70,6 @@ class Oauth2Authenticator extends AbstractAuthenticator
             $accessToken = $this->serverService->verifyAccessToken($tokenString);
 
             $user = $accessToken->getUser();
-            $client = $accessToken->getClient();
 
             if (null !== $user) {
                 try {
@@ -93,7 +92,7 @@ class Oauth2Authenticator extends AbstractAuthenticator
 
             $accessTokenBadge = new AccessTokenBadge($accessToken, $roles);
 
-            return new SelfValidatingPassport(new UserBadge($client->getUserIdentifier()), [$accessTokenBadge]);
+            return new SelfValidatingPassport(new UserBadge($user->getUserIdentifier()), [$accessTokenBadge]);
         } catch (OAuth2ServerException $e) {
             throw new AuthenticationException('OAuth2 authentication failed', 0, $e);
         }


### PR DESCRIPTION
Feel free to enlighten me, but using the client id uses a random number for the username, vs the actual user's username.

This also addresses the problem of if a custom ClientManager is used (ie. a static list/external service/etc), and the $accessToken->getClient() doesn't actually reference any client, then an error is thrown indicating the $client var within $accessToken needs to be set before it can be accessed (php8 error).

Thanks for reviewing my PR - nice job on getting the project working with Symfony6.