### PR TITLE
Fix OAuthStorage::checkGrantExtension return strict type

### DIFF
--- a/Storage/OAuthStorage.php
+++ b/Storage/OAuthStorage.php
@@ -236,7 +236,7 @@ class OAuthStorage implements IOAuth2RefreshTokens, IOAuth2GrantUser, IOAuth2Gra
     /**
      * {@inheritdoc}
      */
-    public function checkGrantExtension(IOAuth2Client $client, $uri, array $inputData, array $authHeaders): bool
+    public function checkGrantExtension(IOAuth2Client $client, $uri, array $inputData, array $authHeaders): bool|array
     {
         if (!isset($this->grantExtensions[$uri])) {
             throw new OAuth2ServerException(Response::HTTP_BAD_REQUEST, OAuth2::ERROR_UNSUPPORTED_GRANT_TYPE);

--- a/Tests/Storage/OAuthStorageTest.php
+++ b/Tests/Storage/OAuthStorageTest.php
@@ -515,6 +515,30 @@ class OAuthStorageTest extends TestCase
         $this->assertTrue($this->storage->checkGrantExtension($client, 'https://friendsofsymfony.com/grants/foo', [], []));
     }
 
+    public function testValidGrantExtensionWithData(): void
+    {
+        $grantExtension = $this->getMockBuilder('FOS\OAuthServerBundle\Storage\GrantExtensionInterface')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $grantExtensionData = ['data' => 'Foo'];
+        $grantExtension
+            ->expects($this->once())
+            ->method('checkGrantExtension')
+            ->will($this->returnValue($grantExtensionData))
+        ;
+        $this->storage->setGrantExtension('https://friendsofsymfony.com/grants/foo', $grantExtension);
+
+        $client = $this->getMockBuilder('OAuth2\Model\IOAuth2Client')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $this->assertEquals(
+            $grantExtensionData,
+            $this->storage->checkGrantExtension($client, 'https://friendsofsymfony.com/grants/foo', [], [])
+        );
+    }
+
     public function testInvalidGrantExtension(): void
     {
         $this->expectException(\OAuth2\OAuth2ServerException::class);


### PR DESCRIPTION
\OAuth2\IOAuth2GrantExtension::checkGrantExtension has bool|array return type:
```php
/**
....
     *
     * @return bool|array Returns false if the authorization is rejected or not support. Returns true or an associative array if you
     * want to verify the scope:
     * @code
     * return array(
     * 'scope' => <stored scope values (space-separated string)>,
     * );
     * @endcode
     *
     * @see http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-1.4.5
     * @see http://tools.ietf.org/html/draft-ietf-oauth-v2-20#section-4.2
     */
``` 

This PR fixes return strict type and adds a unit test to ensure its stability in the future.