### PR TITLE
fix: allow nullable parameter in Client::checkSecret()

### DIFF
--- a/Model/Client.php
+++ b/Model/Client.php
@@ -87,7 +87,7 @@ class Client implements ClientInterface
     /**
      * {@inheritdoc}
      */
-    public function checkSecret(string $secret): bool
+    public function checkSecret(?string $secret): bool
     {
         return null === $this->secret || $secret === $this->secret;
     }


### PR DESCRIPTION
I'm having the issue where the secret to check is `null`, as is the `Client::$secret`.
The call to the secret check throws an exception, though, since the check method does not accept a `null` value. 
I've changed the method to also accept `null` values.