### PR TITLE
Fix issue in Authenticator

### DIFF
--- a/Security/Authenticator/Oauth2Authenticator.php
+++ b/Security/Authenticator/Oauth2Authenticator.php
@@ -96,7 +96,7 @@ class Oauth2Authenticator extends AbstractAuthenticator
 
             $accessTokenBadge = new AccessTokenBadge($accessToken, $roles);
 
-            return new SelfValidatingPassport(new UserBadge($client->getUserIdentifier()), [$accessTokenBadge]);
+            return new SelfValidatingPassport(new UserBadge($user->getUserIdentifier()), [$accessTokenBadge]);
         } catch (OAuth2ServerException $e) {
             throw new AuthenticationException('OAuth2 authentication failed', 0, $e);
         }


### PR DESCRIPTION
## What does this PR do?

When I was using the `klapaudius` (FOS) Oauth Server Bundle. The authentication calls (`/oauth/v2/token`) worked fine. But the next call (with a valid bearer token!) failed.

After some debugging I noticed the primary badge (the `UserBadge` contained a very weird identifier (which after some looking around proofed to be my OauthClient -> id. Looking at this piece of code, initializing a **User**Badge with `$client`  instead of the (available) `$user` feels wrong. Same or calling `getUserIdentifier()` on `$client`.

If you could please merge and tag this, I don't have to submit a version to packagist myself! Very nice work on the port of this bundle to the new symfony authentication manager.