### PR TITLE
replacement fieldName attribute in mongodb configuration

### DIFF
--- a/Resources/config/doctrine/AccessToken.mongodb.xml
+++ b/Resources/config/doctrine/AccessToken.mongodb.xml
@@ -5,8 +5,8 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\AccessToken">
-        <field name="token" fieldName="token" type="string" unique="true" />
-        <field name="expiresAt" fieldName="expiresAt" type="int" nullable="true" />
-        <field name="scope" fieldName="scope" type="string" nullable="true" />
+        <field field-name="token" type="string" unique="true" />
+        <field field-name="expiresAt" type="int" nullable="true" />
+        <field field-name="scope" type="string" nullable="true" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/AuthCode.mongodb.xml
+++ b/Resources/config/doctrine/AuthCode.mongodb.xml
@@ -5,9 +5,9 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\AuthCode">
-        <field name="token" fieldName="token" type="string" unique="true" />
-        <field name="redirectUri" fieldName="redirectUri" type="string" />
-        <field name="expiresAt" fieldName="expiresAt" type="int" nullable="true" />
-        <field name="scope" fieldName="scope" type="string" nullable="true" />
+        <field field-name="token" type="string" unique="true" />
+        <field field-name="redirectUri" type="string" />
+        <field field-name="expiresAt" type="int" nullable="true" />
+        <field field-name="scope" type="string" nullable="true" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/Client.mongodb.xml
+++ b/Resources/config/doctrine/Client.mongodb.xml
@@ -5,9 +5,9 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\Client">
-        <field name="randomId" fieldName="randomId" type="string" />
-        <field name="redirectUris" fieldName="redirectUris" type="collection" />
-        <field name="secret" fieldName="secret" type="string" />
-        <field name="allowedGrantTypes" fieldName="allowedGrantTypes" type="collection" />
+        <field field-name="randomId" type="string" />
+        <field field-name="redirectUris" type="collection" />
+        <field field-name="secret" type="string" />
+        <field field-name="allowedGrantTypes" type="collection" />
     </mapped-superclass>
 </doctrine-mongo-mapping>

--- a/Resources/config/doctrine/RefreshToken.mongodb.xml
+++ b/Resources/config/doctrine/RefreshToken.mongodb.xml
@@ -5,8 +5,8 @@
                         http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
     <mapped-superclass name="FOS\OAuthServerBundle\Document\RefreshToken">
-        <field name="token" fieldName="token" type="string" unique="true" />
-        <field name="expiresAt" fieldName="expiresAt" type="int" nullable="true" />
-        <field name="scope" fieldName="scope" type="string" nullable="true" />
+        <field field-name="token" type="string" unique="true" />
+        <field field-name="expiresAt" type="int" nullable="true" />
+        <field field-name="scope" type="string" nullable="true" />
     </mapped-superclass>
 </doctrine-mongo-mapping>


### PR DESCRIPTION
in newer versions of `mongodb-odm` attribute `fieldName` has been renamed to `field-name`
https://github.com/doctrine/mongodb-odm/blob/2.9.x/UPGRADE-2.0.md?plain=1#L145