### PR TITLE
doctrine/orm v3 compatibility fix

### DIFF
--- a/Entity/AuthCodeManager.php
+++ b/Entity/AuthCodeManager.php
@@ -17,6 +17,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use FOS\OAuthServerBundle\Model\AuthCodeInterface;
 use FOS\OAuthServerBundle\Model\AuthCodeManager as BaseAuthCodeManager;
 
+use function time;
+
 class AuthCodeManager extends BaseAuthCodeManager
 {
     /**
@@ -80,8 +82,8 @@ class AuthCodeManager extends BaseAuthCodeManager
         $qb = $repository->createQueryBuilder('a');
         $qb
             ->delete()
-            ->where('a.expiresAt < ?1')
-            ->setParameters([1 => time()])
+            ->where('a.expiresAt < :time')
+            ->setParameter('time', time())
         ;
 
         return $qb->getQuery()->execute();

--- a/Entity/TokenManager.php
+++ b/Entity/TokenManager.php
@@ -18,6 +18,8 @@ use Doctrine\ORM\EntityRepository;
 use FOS\OAuthServerBundle\Model\TokenInterface;
 use FOS\OAuthServerBundle\Model\TokenManager as BaseTokenManager;
 
+use function time;
+
 class TokenManager extends BaseTokenManager
 {
     /**
@@ -88,8 +90,8 @@ class TokenManager extends BaseTokenManager
         $qb = $this->repository->createQueryBuilder('t');
         $qb
             ->delete()
-            ->where('t.expiresAt < ?1')
-            ->setParameters([1 => time()])
+            ->where('t.expiresAt < :time')
+            ->setParameter('time', time())
         ;
 
         return $qb->getQuery()->execute();

--- a/Tests/Entity/AuthCodeManagerTest.php
+++ b/Tests/Entity/AuthCodeManagerTest.php
@@ -170,14 +170,14 @@ class AuthCodeManagerTest extends TestCase
         $queryBuilder
             ->expects($this->once())
             ->method('where')
-            ->with('a.expiresAt < ?1')
+            ->with('a.expiresAt < :time')
             ->willReturn($queryBuilder)
         ;
 
         $queryBuilder
             ->expects($this->once())
-            ->method('setParameters')
-            ->with([1 => time()])
+            ->method('setParameter')
+            ->with('time', time())
             ->willReturn($queryBuilder)
         ;
 

--- a/Tests/Entity/TokenManagerTest.php
+++ b/Tests/Entity/TokenManagerTest.php
@@ -177,14 +177,14 @@ class TokenManagerTest extends TestCase
         $queryBuilder
             ->expects($this->once())
             ->method('where')
-            ->with('t.expiresAt < ?1')
+            ->with('t.expiresAt < :time')
             ->willReturn($queryBuilder)
         ;
 
         $queryBuilder
             ->expects($this->once())
-            ->method('setParameters')
-            ->with([1 => time()])
+            ->method('setParameter')
+            ->with('time', time())
             ->willReturn($queryBuilder)
         ;
 


### PR DESCRIPTION
Hi,
converted setParameters to simple setParameter.
setParameters in orm v3 expects ArrayCollection.

It was easier to convert to simple setParameter which works the same in v2 and v3.
