### PR TITLE
Use nullsafe getUser() operator in AuthorizeController

### DIFF
--- a/Controller/AuthorizeController.php
+++ b/Controller/AuthorizeController.php
@@ -66,7 +66,7 @@ class AuthorizeController
      */
     public function authorizeAction(Request $request, AuthorizeFormHandler $formHandler, Environment $twig): Response
     {
-        $user = $this->tokenStorage->getToken()->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
         if (!$user instanceof UserInterface) {
             throw new AccessDeniedException('This user does not have access to this section.');
         }


### PR DESCRIPTION
`TokenStorageInterface::getToken()` might return `null`. The controller should account for that.

Fixes #39