### PR TITLE
Fix deprecated xml loader for non-string resources

### DIFF
--- a/Routing/DeprecatedXmlFileLoader.php
+++ b/Routing/DeprecatedXmlFileLoader.php
@@ -55,6 +55,10 @@ class DeprecatedXmlFileLoader extends YamlFileLoader
 
     public function supports(mixed $resource, ?string $type = null): bool
     {
+        if (! is_string($resource)) {
+            return false;
+        }
+
         $filename = basename($resource);
         $yamlFile = str_replace('.xml', '.yaml', $resource);
 


### PR DESCRIPTION
Avoid errors like
```
basename(): Argument #1 ($path) must be of type string, array given
```