### PR TITLE
Fix YAML escape sequences in mongodb.yaml and couchdb.yaml

### DIFF
--- a/Resources/config/couchdb.yaml
+++ b/Resources/config/couchdb.yaml
@@ -1,31 +1,31 @@
 services:
     fos_oauth_server.client_manager.default:
-        class: "FOS\OAuthServerBundle\CouchDocument\ClientManager"
+        class: "FOS\\OAuthServerBundle\\CouchDocument\\ClientManager"
         arguments:
             - "@fos_oauth_server.document_manager"
             - "%fos_oauth_server.model.client.class%"
 
     fos_oauth_server.access_token_manager.default:
-        class: "FOS\OAuthServerBundle\CouchDocument\AccessTokenManager"
+        class: "FOS\\OAuthServerBundle\\CouchDocument\\AccessTokenManager"
         arguments:
             - "@fos_oauth_server.document_manager"
             - "%fos_oauth_server.model.access_token.class%"
 
     fos_oauth_server.auth_code_manager.default:
-        class: "FOS\OAuthServerBundle\CouchDocument\AuthCodeManager"
+        class: "FOS\\OAuthServerBundle\\CouchDocument\\AuthCodeManager"
         arguments:
             - "@fos_oauth_server.document_manager"
             - "%fos_oauth_server.model.auth_code.class%"
 
     fos_oauth_server.refresh_token_manager.default:
-        class: "FOS\OAuthServerBundle\CouchDocument\RefreshTokenManager"
+        class: "FOS\\OAuthServerBundle\\CouchDocument\\RefreshTokenManager"
         arguments:
             - "@fos_oauth_server.document_manager"
             - "%fos_oauth_server.model.refresh_token.class%"
 
     fos_user.document_manager:
         public: false
-        class: "Doctrine\ODM\CouchDB\DocumentManager"
+        class: "Doctrine\\ODM\\CouchDB\\DocumentManager"
         factory: [ "@doctrine_couchdb", "getObjectManager" ]
         arguments:
             - "%fos_oauth_server.model_manager_name%"

--- a/Resources/config/mongodb.yaml
+++ b/Resources/config/mongodb.yaml
@@ -1,24 +1,24 @@
 services:
     fos_oauth_server.client_manager.default:
-        class: "FOS\OAuthServerBundle\Document\ClientManager"
+        class: "FOS\\OAuthServerBundle\\Document\\ClientManager"
         arguments:
             - "@fos_oauth_server.document_manager"
             - "%fos_oauth_server.model.client.class%"
 
     fos_oauth_server.access_token_manager.default:
-        class: "FOS\OAuthServerBundle\Document\AccessTokenManager"
+        class: "FOS\\OAuthServerBundle\\Document\\AccessTokenManager"
         arguments:
             - "@fos_oauth_server.document_manager"
             - "%fos_oauth_server.model.access_token.class%"
 
     fos_oauth_server.auth_code_manager.default:
-        class: "FOS\OAuthServerBundle\Document\AuthCodeManager"
+        class: "FOS\\OAuthServerBundle\\Document\\AuthCodeManager"
         arguments:
             - "@fos_oauth_server.document_manager"
             - "%fos_oauth_server.model.auth_code.class%"
 
     fos_oauth_server.refresh_token_manager.default:
-        class: "FOS\OAuthServerBundle\Document\RefreshTokenManager"
+        class: "FOS\\OAuthServerBundle\\Document\\RefreshTokenManager"
         arguments:
             - "@fos_oauth_server.document_manager"
             - "%fos_oauth_server.model.refresh_token.class%"


### PR DESCRIPTION
Escape backslashes in double-quoted class names to comply with the YAML specification. In YAML double-quoted strings, a single backslash starts an escape sequence (e.g. \O, \C, \D are invalid), causing a parse error with strict YAML parsers such as Symfony Yaml 7.4+:
`Found unknown escape character "\O"`

Other config files (orm.yaml, oauth.yaml, authorize.yaml, security.yaml) already use properly escaped double backslashes.
